### PR TITLE
Iceborne: allow certain files to be read

### DIFF
--- a/src/mhw_armor_edit/assets/armor_editor.ui
+++ b/src/mhw_armor_edit/assets/armor_editor.ui
@@ -551,7 +551,7 @@
              <number>0</number>
             </property>
             <property name="maximum">
-             <number>3</number>
+             <number>4</number>
             </property>
             <property name="bind_field" stdset="0">
              <string>gem_slot_lvl1</string>
@@ -571,7 +571,7 @@
              <number>0</number>
             </property>
             <property name="maximum">
-             <number>3</number>
+             <number>4</number>
             </property>
             <property name="bind_field" stdset="0">
              <string>gem_slot_lvl2</string>
@@ -591,7 +591,7 @@
              <number>0</number>
             </property>
             <property name="maximum">
-             <number>3</number>
+             <number>4</number>
             </property>
             <property name="bind_field" stdset="0">
              <string>gem_slot_lvl3</string>

--- a/src/mhw_armor_edit/assets/weapon_editor.ui
+++ b/src/mhw_armor_edit/assets/weapon_editor.ui
@@ -641,7 +641,7 @@
              <number>0</number>
             </property>
             <property name="maximum">
-             <number>3</number>
+             <number>4</number>
             </property>
             <property name="bind_field" stdset="0">
              <string>gem_slot_lvl1</string>
@@ -661,7 +661,7 @@
              <number>0</number>
             </property>
             <property name="maximum">
-             <number>3</number>
+             <number>4</number>
             </property>
             <property name="bind_field" stdset="0">
              <string>gem_slot_lvl2</string>
@@ -681,7 +681,7 @@
              <number>0</number>
             </property>
             <property name="maximum">
-             <number>3</number>
+             <number>4</number>
             </property>
             <property name="bind_field" stdset="0">
              <string>gem_slot_lvl3</string>

--- a/src/mhw_armor_edit/ftypes/__init__.py
+++ b/src/mhw_armor_edit/ftypes/__init__.py
@@ -148,8 +148,9 @@ class StructMeta(type):
 class StructFile:
     EntryFactory = None
     MAGIC = None
-    NUM_ENTRY_OFFSET = 2
-    ENTRY_OFFSET = 6
+    MAGIC_OFFSET = 4
+    NUM_ENTRY_OFFSET = 6
+    ENTRY_OFFSET = 10
 
     def __init__(self, data):
         self.modified = False
@@ -188,17 +189,17 @@ class StructFile:
 
     @classmethod
     def check_header(cls, data):
-        result = struct.unpack_from("<H", data, 0)
+        result = struct.unpack_from('<H', data, cls.MAGIC_OFFSET)
         if result[0] != cls.MAGIC:
             raise InvalidDataError(
-                f"magic byte invalid: expected {cls.MAGIC:04X}, "
+                f"magic byte invalid on type {cls.__name__}: expected {cls.MAGIC:04X}, "
                 f"found {result[0]:04X}")
         result = struct.unpack_from("<I", data, cls.NUM_ENTRY_OFFSET)
         num_entries = result[0]
         entries_size = num_entries * cls.EntryFactory.STRUCT_SIZE
         data_entries_size = len(data) - cls.ENTRY_OFFSET
         if data_entries_size != entries_size:
-            raise InvalidDataError(f"total size invalid: "
+            raise InvalidDataError(f"total size invalid on type {cls.__name__}: "
                                    f"expected {entries_size} bytes, "
                                    f"found {data_entries_size}")
         return True

--- a/src/mhw_armor_edit/ftypes/am_dat.py
+++ b/src/mhw_armor_edit/ftypes/am_dat.py
@@ -49,5 +49,5 @@ class AmDatEntry(Struct):
 
 
 class AmDat(StructFile):
-    MAGIC = 0x005d
+    MAGIC = 0x005F
     EntryFactory = AmDatEntry

--- a/src/mhw_armor_edit/ftypes/bbtbl.py
+++ b/src/mhw_armor_edit/ftypes/bbtbl.py
@@ -15,4 +15,4 @@ class BbtblEntry(Struct):
 
 class Bbtbl(StructFile):
     EntryFactory = BbtblEntry
-    MAGIC = 0x01A6
+    MAGIC = 0x021D

--- a/src/mhw_armor_edit/ftypes/eq_crt.py
+++ b/src/mhw_armor_edit/ftypes/eq_crt.py
@@ -4,13 +4,14 @@ from mhw_armor_edit.ftypes import StructFile, Struct
 
 
 class EqCrtEntry(Struct):
-    STRUCT_SIZE = 33
+    STRUCT_SIZE = 37
     equip_type: ft.ubyte()
     equip_id: ft.ushort()
-    key_item: ft.ushort()
+    key_item: ft.ushort()   
     unk1: ft.int()
     unk2: ft.uint()
     rank: ft.uint()
+    unk7: ft.pad(4)
     item1_id: ft.ushort()
     item1_qty: ft.ubyte()
     item2_id: ft.ushort()
@@ -27,4 +28,4 @@ class EqCrtEntry(Struct):
 
 class EqCrt(StructFile):
     EntryFactory = EqCrtEntry
-    MAGIC = 0x0051
+    MAGIC = 0x0079

--- a/src/mhw_armor_edit/ftypes/eq_cus.py
+++ b/src/mhw_armor_edit/ftypes/eq_cus.py
@@ -30,4 +30,4 @@ class EqCusEntry(Struct):
 
 class EqCus(StructFile):
     EntryFactory = EqCusEntry
-    MAGIC = 0x0051
+    MAGIC = 0x0058

--- a/src/mhw_armor_edit/ftypes/itm.py
+++ b/src/mhw_armor_edit/ftypes/itm.py
@@ -39,4 +39,4 @@ class ItmEntry(Struct):
 
 class Itm(StructFile):
     EntryFactory = ItmEntry
-    MAGIC = 0x00AE
+    MAGIC = 0x00BD

--- a/src/mhw_armor_edit/ftypes/kire.py
+++ b/src/mhw_armor_edit/ftypes/kire.py
@@ -17,4 +17,4 @@ class KireEntry(Struct):
 
 class Kire(StructFile):
     EntryFactory = KireEntry
-    MAGIC = 0x0177
+    MAGIC = 0x01C1

--- a/src/mhw_armor_edit/ftypes/sh_tbl.py
+++ b/src/mhw_armor_edit/ftypes/sh_tbl.py
@@ -56,4 +56,4 @@ class ShlTblEntry(Struct):
 
 class ShlTbl(StructFile):
     EntryFactory = ShlTblEntry
-    MAGIC = 0x01A6
+    MAGIC = 0x021D

--- a/src/mhw_armor_edit/ftypes/skl_dat.py
+++ b/src/mhw_armor_edit/ftypes/skl_dat.py
@@ -15,4 +15,4 @@ class SklDatEntry(Struct):
 
 class SklDat(StructFile):
     EntryFactory = SklDatEntry
-    MAGIC = 0x005E
+    MAGIC = 0x0087

--- a/src/mhw_armor_edit/ftypes/wep_wsl.py
+++ b/src/mhw_armor_edit/ftypes/wep_wsl.py
@@ -13,4 +13,4 @@ class WepWslEntry(Struct):
 
 class WepWsl(StructFile):
     EntryFactory = WepWslEntry
-    MAGIC = 0x0177
+    MAGIC = 0x01C1

--- a/src/mhw_armor_edit/ftypes/wp_dat.py
+++ b/src/mhw_armor_edit/ftypes/wp_dat.py
@@ -4,12 +4,14 @@ from mhw_armor_edit.ftypes import StructFile, Struct
 
 
 class WpDatEntry(Struct):
-    STRUCT_SIZE = 65
+    STRUCT_SIZE = 66
     id: ft.uint()
-    unk1: ft.ushort()
+    unk1: ft.ubyte()
+    unk6: ft.ubyte()
     base_model_id: ft.ushort()
     part1_id: ft.ushort()
     part2_id: ft.ushort()
+    unk7: ft.ubyte()
     color: ft.ubyte()
     tree_id: ft.ubyte()
     is_fixed_upgrade: ft.ubyte()
@@ -44,4 +46,4 @@ class WpDatEntry(Struct):
 
 class WpDat(StructFile):
     EntryFactory = WpDatEntry
-    MAGIC = 0x0186
+    MAGIC = 0x01C1

--- a/src/mhw_armor_edit/ftypes/wp_dat_g.py
+++ b/src/mhw_armor_edit/ftypes/wp_dat_g.py
@@ -5,12 +5,13 @@ from mhw_armor_edit.ftypes import StructFile, Struct
 
 
 class WpDatGEntry(Struct):
-    STRUCT_SIZE = 68
+    STRUCT_SIZE = 69
     id: ft.uint()
     unk1: ft.ushort()
     base_model_id: ft.short()
     part1_id: ft.short()
     part2_id: ft.short()
+    unk7: ft.ubyte()
     color: ft.ubyte()
     tree_id: ft.ubyte()
     is_fixed_upgrade: ft.ubyte()
@@ -49,4 +50,4 @@ class WpDatGEntry(Struct):
 
 class WpDatG(StructFile):
     EntryFactory = WpDatGEntry
-    MAGIC = 0x01B1
+    MAGIC = 0x021D


### PR DESCRIPTION
This allows some structs (mostly weapon/armor related) to be read in iceborne. Only tested for reading and exporting.

Currently it assumes that all structs have the same 4 "iceborne magic bytes", but if that assumption does not hold it should be relatively simple to add a new class variable.